### PR TITLE
fix: alter initMarkedNewsItems way

### DIFF
--- a/app/src/main/java/com/weiran/mynowinandroid/foryou/FeedViewModel.kt
+++ b/app/src/main/java/com/weiran/mynowinandroid/foryou/FeedViewModel.kt
@@ -55,16 +55,21 @@ class FeedViewModel @Inject constructor(
         withContext(ioDispatcher) {
             val markedNewsIds = localStorage.getMarkedNewsIds()
             if (markedNewsIds.isNotEmpty()) {
-                _feedState.update { it.copy(savedUIState = SavedUIState.NonEmpty) }
+                initMarkedNewsAndSavedUI(markedNewsIds)
             }
-            _feedState.update { it.copy(markedNewsItems = getMarkedNewsByIds(markedNewsIds)) }
         }
     }
 
-    private fun getMarkedNewsByIds(markedNewsIds: List<String>) =
-        _feedState.value.newsItems.filter {
-            markedNewsIds.contains(it.id)
+    private fun initMarkedNewsAndSavedUI(markedNewsIds: List<String>) =
+        _feedState.update {
+            it.copy(
+                savedUIState = SavedUIState.NonEmpty,
+                markedNewsItems = getMarkedNewsByIds(markedNewsIds)
+            )
         }
+
+    private fun getMarkedNewsByIds(markedNewsIds: List<String>) =
+        allNews.filter { markedNewsIds.contains(it.id) }.map { getNewsItemByNes(it) }
 
     private fun initTopicItems() = _feedState.update { it.copy(topicItems = getTopicItems()) }
 
@@ -164,14 +169,7 @@ class FeedViewModel @Inject constructor(
 
     private fun getNewsItemsByNewsTopicId(id: String) =
         allNews.filter { it.topics.contains(id) }.map {
-            NewsItem(
-                id = it.id,
-                title = it.title,
-                content = it.content,
-                url = it.url,
-                headerImageUrl = it.headerImageUrl,
-                topics = getTopicItemsById(it.topics)
-            )
+            getNewsItemByNes(it)
         }
 
     private fun getTopicsByTopicItems(topicItems: List<TopicItem>) = topicItems.map {
@@ -209,6 +207,15 @@ class FeedViewModel @Inject constructor(
             it
         }
     }
+
+    private fun getNewsItemByNes(news: News) = NewsItem(
+        id = news.id,
+        title = news.title,
+        content = news.content,
+        url = news.url,
+        headerImageUrl = news.headerImageUrl,
+        topics = getTopicItemsById(news.topics)
+    )
 
     private fun changeDBMarkedNews(newsItem: NewsItem) {
         viewModelScope.launch(ioDispatcher) {


### PR DESCRIPTION
## Overview

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## In the scope
- for you界面先选中topic收藏其中的news，然后取消选中的topic，之后退出app。重启app之后，saved界面上会任何UI都不显示。此处本该显示收藏的news。

## Out of scope

## Checklist
1. [ ] Makes your submission pass tests?
2. [ ] Have you lint your code locally before submission?
3. [ ] Have you updated the wiki of your change?

## Reference
- Card: https://trello.com/c/NbqQx2li